### PR TITLE
support of csrf token

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -89,8 +89,8 @@ class PassboltAPI:
             passphrase=str(self.config["PASSBOLT"]["PASSPHRASE"])
         ))
 
-	def get_headers(self):
-		return {"X-CSRF-Token": self.requests_session.cookies['csrfToken']}
+    def get_headers(self):
+        return {"X-CSRF-Token": self.requests_session.cookies['csrfToken']}
 
     def get_server_public_key(self):
         r = self.requests_session.get(self.server_url + VERIFY_URL)

--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -89,6 +89,9 @@ class PassboltAPI:
             passphrase=str(self.config["PASSBOLT"]["PASSPHRASE"])
         ))
 
+	def get_headers(self):
+		return {"X-CSRF-Token": self.requests_session.cookies['csrfToken']}
+
     def get_server_public_key(self):
         r = self.requests_session.get(self.server_url + VERIFY_URL)
         return r.json()["body"]["fingerprint"], r.json()["body"]["keydata"]
@@ -98,15 +101,15 @@ class PassboltAPI:
         return r.json()
 
     def post(self, url, data):
-        r = self.requests_session.post(self.server_url + url, json=data)
+        r = self.requests_session.post(self.server_url + url, json=data, headers=self.get_headers())
         return r.json()
 
     def put(self, url, data):
-        r = self.requests_session.put(self.server_url + url, json=data)
+        r = self.requests_session.put(self.server_url + url, json=data, headers=self.get_headers())
         return r.json()
 
     def delete(self, url):
-        r = self.requests_session.delete(self.server_url + url)
+        r = self.requests_session.delete(self.server_url + url, headers=self.get_headers())
         return r.json()
 
     def close_session(self):

--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -90,7 +90,7 @@ class PassboltAPI:
         ))
 
     def get_headers(self):
-        return {"X-CSRF-Token": self.requests_session.cookies['csrfToken']}
+        return {"X-CSRF-Token": self.requests_session.cookies['csrfToken'] if 'csrfToken' in self.requests_session.cookies else ''}
 
     def get_server_public_key(self):
         r = self.requests_session.get(self.server_url + VERIFY_URL)


### PR DESCRIPTION
Hello,

Thank you for your api, it helped me a lot

FYI there is since v2.2.0 a new CSRF security on some api calls (those with modifications)

Here is the documentation
https://help.passbolt.com/releases/pro/v220-i-want-to-break-free
https://help.passbolt.com/api/authentication#working-with-csrf-token

And you have to do a get api call first so the csrf cookie will be set.