### PR TITLE
use configparser interpolation to pass in environment variables

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -9,13 +9,14 @@ VERIFY_URL = "/auth/verify.json"
 
 class PassboltAPI:
 
-    def __init__(self, config_path, new_keys=False, delete_old_keys=False):
+    def __init__(self, config_path, new_keys=False, delete_old_keys=False, env_vars={}):
         """
         :param config_path: Path to the config file.
         :param delete_old_keys: Set true if old keys need to be deleted
+        :param env_vars: dictionary of environment variables used in interpolation by configparser
         """
         self.requests_session = requests.Session()
-        self.config = configparser.ConfigParser()
+        self.config = configparser.ConfigParser(env_vars)
         self.config.read_file(open(config_path, "r"))
 
         if not self.config["PASSBOLT"]["SERVER"]:


### PR DESCRIPTION
This PR adds a keyword argument env_vars to the PassboltAPI initializer that will be passed to `configparser.ConfigParser` and used to interpolate any variables provided in env_vars.  Does not break any existing API use.

If you pass in an environment variable, for example a variable `FOO`:

```
import os
PassboltAPI(config_path='config.ini', env_vars=os.environ)
```

you can use that variable inside the config.ini file via:

```
bar=%(FOO)s
```

If the variable is present both in the env_vars dictionary and the config.ini file then the config.ini value takes precedence.

What you cannot do is use the same name for a variable you are defining and one that you are passing in, such as:

```
FOO=%(FOO)s
```

That will result in a recursion error.