### PR TITLE
Some enhancements and bugfixes

### DIFF
--- a/passboltapi/schema.py
+++ b/passboltapi/schema.py
@@ -99,6 +99,7 @@ class PassboltFolderTuple(NamedTuple):
     modified_by: PassboltUserIdType
     folder_parent_id: PassboltFolderIdType
     personal: bool
+    permissions: List[PassboltPermissionTuple] = []
 
 
 class PassboltGroupTuple(NamedTuple):


### PR DESCRIPTION
* `PassboltFolderTuple` now has an optional permissions field
* `list_users` now populates the permissions field automatically
* `create_resource` now has an optional folder argument that simulates, shares and moves the entry into a folder automatically. With `folder=None` it works the same as before.
* `update_resource` allows one to update the name, username, description or secret as one action.
* Since the philosophy of these methods is to pass tuples between them, I have included a `read_folder` and `read_resource` that accept the ID as input and return the appropriate passbolttuple.