### PR TITLE
Make "PASSPHRASE" optional in the config

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -129,7 +129,13 @@ class APIClient:
         return str(self.gpg.encrypt(data=text, recipients=recipients or self.gpg_fingerprint, always_trust=True))
 
     def decrypt(self, text):
-        return str(self.gpg.decrypt(text, always_trust=True, passphrase=str(self.config["PASSBOLT"]["PASSPHRASE"])))
+        if "PASSPHRASE" in self.config["PASSBOLT"]:
+            passphrase = str(self.config["PASSBOLT"]["PASSPHRASE"])
+        else:
+            passphrase = None
+
+
+        return str(self.gpg.decrypt(text, always_trust=True, passphrase=passphrase))
 
     def get_headers(self):
         return {


### PR DESCRIPTION
This change will allow the passphrase in the config to be empty so gpg-agent can take over
authentication. It will also help avoid having secrets in config files

This will solve #12 