### PR TITLE
Cannot list users by folder access since the has-access filter was closed for folders

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -277,13 +277,27 @@ class PassboltAPI(APIClient):
             "secrets": new_secret
         }, return_response_object=True)
 
-    def list_users(self, resource_or_folder_id: Union[None, PassboltResourceIdType, PassboltFolderIdType] = None,
-                   force_list=True) \
-            -> List[PassboltUserTuple]:
+    def list_users_with_folder_access(self, folder_id: PassboltFolderIdType) -> List[PassboltUserTuple]:
+        folder_tuple = self.describe_folder(folder_id)
+        # resolve users
+        user_ids = set()
+        # resolve users from groups
+        for perm in folder_tuple.permissions:
+            if perm.aro == "Group":
+                group_tuple: PassboltGroupTuple = self.describe_group(perm.aro_foreign_key)
+                for group_user in group_tuple.groups_users:
+                    user_ids.add(group_user["user_id"])
+            elif perm.aro == "User":
+                user_ids.add(perm.aro_foreign_key)
+        return [user for user in self.list_users() if user.id in user_ids]
+
+    def list_users(
+        self, resource_or_folder_id: Union[None, PassboltResourceIdType, PassboltFolderIdType] = None, force_list=True
+    ) -> List[PassboltUserTuple]:
         if resource_or_folder_id is None:
             params = {}
         else:
-            params = {"filter[has-access]": resource_or_folder_id}
+            params = {"filter[has-access]": resource_or_folder_id, "contain[user]": 1}
         params["contain[permission]"] = True
         response = self.get(f"/users.json", params=params)
         assert "body" in response.keys(), f"Key 'body' not found in response keys: {response.keys()}"
@@ -325,7 +339,25 @@ class PassboltAPI(APIClient):
         )
 
     def describe_folder(self, folder_id: PassboltFolderIdType):
-        return self.get(f"/folders/{folder_id}.json")
+        """Shows folder details with permissions that are needed for some downstream task."""
+        response = self.get(
+            f"/folders/{folder_id}.json",
+            params={
+                "contain[permissions]": 1,
+                "contain[permissions.user.profile]": 1,
+                "contain[permissions.group]": 1,
+            },
+        )
+        assert "body" in response.keys(), f"Key 'body' not found in response keys: {response.keys()}"
+        assert (
+            "permissions" in response["body"].keys()
+        ), f"Key 'body.permissions' not found in response: {response['body'].keys()}"
+        return constructor(
+            PassboltFolderTuple,
+            subconstructors={
+                "permissions": constructor(PassboltPermissionTuple),
+            }
+        )(response["body"])
 
     def move_resource_to_folder(self, resource_id: PassboltResourceIdType, folder_id: PassboltFolderIdType):
         r = self.post(
@@ -365,7 +397,7 @@ class PassboltAPI(APIClient):
         if folder_id:
             folder = self.read_folder(folder_id)
             # get users with access to folder
-            users_list = self.list_users(resource_or_folder_id=folder_id)
+            users_list = self.list_users_with_folder_access(folder_id)
             lookup_users: Mapping[PassboltUserIdType, PassboltUserTuple] = {user.id: user for user in users_list}
             self_user_id = [user.id for user in users_list if self.user_fingerprint == user.gpgkey.fingerprint]
             if self_user_id:
@@ -392,7 +424,7 @@ class PassboltAPI(APIClient):
             r_share = self.put(f"/share/resource/{resource.id}.json", share_payload, return_response_object=True)
 
             self.move_resource_to_folder(resource_id=resource.id, folder_id=folder_id)
-        return r_create
+        return resource
 
     def update_resource(
         self,
@@ -461,3 +493,7 @@ class PassboltAPI(APIClient):
         response = self.get(f"/resources/{resource_id}.json", return_response_object=True)
         response = response.json()["body"]
         return constructor(PassboltResourceTuple)(response)
+
+    def describe_group(self, group_id: PassboltGroupIdType):
+        response = self.get(f"/groups/{group_id}.json", params={"contain[groups_users]": 1})
+        return constructor(PassboltGroupTuple)(response["body"])

--- a/passboltapi/schema.py
+++ b/passboltapi/schema.py
@@ -1,6 +1,6 @@
 # Library Imports
 from enum import Enum
-from typing import List, Mapping, NamedTuple, Union
+from typing import List, Mapping, NamedTuple, Optional, Union
 
 from typing_extensions import TypeAlias
 
@@ -47,6 +47,10 @@ class PassboltPermissionTuple(NamedTuple):
     aro: Literal["Resource", "Folder"]
     aro_foreign_key: Union[PassboltResourceIdType, PassboltFolderIdType]
     type: int
+    created: PassboltDateTimeType
+    modified: PassboltDateTimeType
+    group: Union[None, "PassboltGroupTuple"] = None
+    user: Union[None, "PassboltUserTuple"] = None
 
 
 class PassboltOpenPgpKeyTuple(NamedTuple):
@@ -72,9 +76,9 @@ class PassboltUserTuple(NamedTuple):
     username: str
     role_id: PassboltRoleIdType
     profile: dict
-    role: dict
-    gpgkey: PassboltOpenPgpKeyTuple
     last_logged_in: PassboltDateTimeType
+    role: Optional[dict] = None
+    gpgkey: Optional[PassboltOpenPgpKeyTuple] = None
 
 
 class PassboltResourceTuple(NamedTuple):
@@ -126,6 +130,7 @@ class PassboltGroupTuple(NamedTuple):
     modified: PassboltDateTimeType
     modified_by: PassboltUserIdType
     name: str
+    groups_users: List[dict] = []
 
 
 AllPassboltTupleTypes = Union[

--- a/passboltapi/schema.py
+++ b/passboltapi/schema.py
@@ -151,6 +151,8 @@ def constructor(
         2. Renames field names from dict -> namedtuple
         3. Filters out dictionary keys that do not exist in namedtuple
         4. Can apply further constructors to subfields"""
+        if data is None:
+            return
         # 1. ingest datatypes
         is_singleton = False
         if isinstance(data, dict):


### PR DESCRIPTION
[This commit](https://github.com/passbolt/passbolt_api/commit/235703bc28a87f4a1c2a9e9667b9635fa7752f6b) resulted in an documented api feature whereby `/users.json` with `filter[has-access]=>folder_id>` could refer to folders and not just resources, was fixed.

Affected use: replace `client.list_users(resource_or_folder_id=folder_id)` has been replaced by `client.list_users_with_folder_access(folder_id)`. 