### PR TITLE
Take into account fingerprints with spaces in them as they are in the Passbolt instance

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -69,7 +69,7 @@ class APIClient:
             raise ValueError("Missing value for SERVER in config.ini")
 
         self.server_url = self.config["PASSBOLT"]["SERVER"].rstrip("/")
-        self.user_fingerprint = self.config["PASSBOLT"]["USER_FINGERPRINT"].upper()
+        self.user_fingerprint = self.config["PASSBOLT"]["USER_FINGERPRINT"].upper().replace(" ", "")
         self.gpg = gnupg.GPG()
         if delete_old_keys:
             self._delete_old_keys()


### PR DESCRIPTION
When downloading a key pair from a Passbolt instance, the `Fingerprint` field contains spaces between every 2 bytes. 

If an user places this fingerprint in his fingerprint file instead of the one obtained from `gpg --list-keys`, it will cause a "Key not found" error when searching for key fingerprints with GPG, even if it's been imported.

This MR simply removes the spaces from the key in the file.