### PR TITLE
create_resource: Issue when folder_id is set and not all users keys are imported.

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -388,6 +388,10 @@ class PassboltAPI(APIClient):
             folder = self.read_folder(folder_id)
             # get users with access to folder
             users_list = self.list_users_with_folder_access(folder_id)
+            
+            # import users key to GPG otherwise secret share will fail
+            for user in users_list: self.gpg.import_keys(user.gpgkey.armored_key)
+
             lookup_users: Mapping[PassboltUserIdType, PassboltUserTuple] = {user.id: user for user in users_list}
             self_user_id = [user.id for user in users_list if self.user_fingerprint == user.gpgkey.fingerprint]
             if self_user_id:


### PR DESCRIPTION
Without importing all users GPG keys, the secret sharing to a folder will fail.

On the share_payload you will receive an error saying the PGP message is empty: 
{'user_id': 'XXXXXXXXXXXX', 'data': ''}]}
ERROR:root:{"header":{"id":"XXXX-0bdc-43f0-8d16-XX","status":"error","servertime":1708009984,"action":"XXXX-9d43-5749-a5fe-XX","message":"Could not validate resource data.","url":"\/share\/resource\/XX-7d37-4b13-a86c-XX.json","code":400},"body":{"secrets":{"1":{"data":{"_empty":"The message should not be empty."}}}}
