### PR TITLE
Adding an option to disable SSL verification during logging

### DIFF
--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -51,12 +51,14 @@ class APIClient:
         config_path: Optional[str] = None,
         new_keys: bool = False,
         delete_old_keys: bool = False,
+        verify: bool = False,
     ):
         """
         :param config: Config as a dictionary
         :param config_path: Path to the config file.
         :param delete_old_keys: Set true if old keys need to be deleted
         """
+        self.verify = verify
         self.config = config
         if config_path:
             self.config = configparser.ConfigParser()
@@ -109,7 +111,7 @@ class APIClient:
         self.gpg.import_keys(open(self.config["PASSBOLT"]["USER_PRIVATE_KEY_FILE"], "r").read())
 
     def _login(self):
-        r = self.requests_session.post(self.server_url + LOGIN_URL, json={"gpg_auth": {"keyid": self.gpg_fingerprint}})
+        r = self.requests_session.post(self.server_url + LOGIN_URL, json={"gpg_auth": {"keyid": self.gpg_fingerprint}}, verify=self.verify)
         encrypted_token = r.headers["X-GPGAuth-User-Auth-Token"]
         encrypted_token = urllib.parse.unquote(encrypted_token)
         encrypted_token = encrypted_token.replace("\+", " ")

--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -51,7 +51,7 @@ class APIClient:
         config_path: Optional[str] = None,
         new_keys: bool = False,
         delete_old_keys: bool = False,
-        verify: bool = False,
+        ssl_verify: bool = False,
     ):
         """
         :param config: Config as a dictionary

--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -58,7 +58,7 @@ class APIClient:
         :param config_path: Path to the config file.
         :param delete_old_keys: Set true if old keys need to be deleted
         """
-        self.verify = verify
+        self.ssl_verify = ssl_verify
         self.config = config
         if config_path:
             self.config = configparser.ConfigParser()

--- a/passboltapi/__init__.py
+++ b/passboltapi/__init__.py
@@ -111,7 +111,7 @@ class APIClient:
         self.gpg.import_keys(open(self.config["PASSBOLT"]["USER_PRIVATE_KEY_FILE"], "r").read())
 
     def _login(self):
-        r = self.requests_session.post(self.server_url + LOGIN_URL, json={"gpg_auth": {"keyid": self.gpg_fingerprint}}, verify=self.verify)
+        r = self.requests_session.post(self.server_url + LOGIN_URL, json={"gpg_auth": {"keyid": self.gpg_fingerprint}}, verify=self.ssl_verify)
         encrypted_token = r.headers["X-GPGAuth-User-Auth-Token"]
         encrypted_token = urllib.parse.unquote(encrypted_token)
         encrypted_token = encrypted_token.replace("\+", " ")


### PR DESCRIPTION
People may encounter the problem that their server is not responding on port 80, like mine. Your [readme.md ](README.md)states that the `SERVER` variable must be set to HTTP
`SERVER = http://<server_ip or domain>`

If I use HTTPS, in my case with a Let's Encrypt certificate I get an error:
```bash
requests.exceptions.SSLError: HTTPSConnectionPool(host='mypassbolt.de', port=443): Max retries exceeded with url: /auth/login.json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1133)')))
```

For test sending I don't need to verify SSL and would like to have the `verify=False` option for such cases

I solved this by adding a flag to your library.
To do this we need to change your [__init__.py](passboltapi/__init__.py) a little

I find it very useful for debugging and development, by default verify has the True flag, it does not break security, it is only user's discretion to enable this flag.

My team and I would appreciate it if you could release this in a new version of your code so that it can be used through the pip package manager